### PR TITLE
Fix recipe to work with latest rattler-build release

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -11,7 +11,7 @@ source:
     sha256: 2dd0f148288f2322ddc217ce27ec77fdfea4fc6ac26e7d4f026c2eba41145c98
 
 build:
-  number: 0
+  number: 1
   script: ${{ PYTHON }} -m pip install .
   noarch: python
 
@@ -33,7 +33,7 @@ tests:
   - python:
       imports:
         - mxbai_rerank
-      python_version: ${{ python_min }}
+      python_version: ${{ python_min }}.*
       pip_check: true
 
 about:


### PR DESCRIPTION
Add explicit `.*` glob suffix to bare python version specifiers like `python ${{ python_min }}` to make them valid match specs.